### PR TITLE
move OnLoadNewsListListener and OnLoadNewsDetailListener

### DIFF
--- a/app/src/main/java/com/lauren/simplenews/news/model/NewsModel.java
+++ b/app/src/main/java/com/lauren/simplenews/news/model/NewsModel.java
@@ -9,8 +9,8 @@ package com.lauren.simplenews.news.model;
  */
 public interface NewsModel {
 
-    void loadNews(String url, int type, NewsModelImpl.OnLoadNewsListListener listener);
+    void loadNews(String url, int type, OnLoadNewsListListener listener);
 
-    void loadNewsDetail(String docid, NewsModelImpl.OnLoadNewsDetailListener listener);
+    void loadNewsDetail(String docid, OnLoadNewsDetailListener listener);
 
 }

--- a/app/src/main/java/com/lauren/simplenews/news/model/NewsModelImpl.java
+++ b/app/src/main/java/com/lauren/simplenews/news/model/NewsModelImpl.java
@@ -96,14 +96,4 @@ public class NewsModelImpl implements NewsModel {
         return sb.toString();
     }
 
-    public interface OnLoadNewsListListener {
-        void onSuccess(List<NewsBean> list);
-        void onFailure(String msg, Exception e);
-    }
-
-    public interface OnLoadNewsDetailListener {
-        void onSuccess(NewsDetailBean newsDetailBean);
-        void onFailure(String msg, Exception e);
-    }
-
 }

--- a/app/src/main/java/com/lauren/simplenews/news/model/OnLoadNewsDetailListener.java
+++ b/app/src/main/java/com/lauren/simplenews/news/model/OnLoadNewsDetailListener.java
@@ -1,0 +1,16 @@
+package com.lauren.simplenews.news.model;
+
+import com.lauren.simplenews.beans.NewsDetailBean;
+
+/**
+ * Description : 新闻详情加载回调
+ * Author : AstroGypsophila
+ * Github  : https://github.com/AstroGypsophila
+ * Date   : 2016/8/28
+ */
+public interface OnLoadNewsDetailListener {
+
+    void onSuccess(NewsDetailBean newsDetailBean);
+
+    void onFailure(String msg, Exception e);
+}

--- a/app/src/main/java/com/lauren/simplenews/news/model/OnLoadNewsListListener.java
+++ b/app/src/main/java/com/lauren/simplenews/news/model/OnLoadNewsListListener.java
@@ -1,0 +1,18 @@
+package com.lauren.simplenews.news.model;
+
+import com.lauren.simplenews.beans.NewsBean;
+
+import java.util.List;
+
+/**
+ * Description : 新闻列表加载回调
+ * Author : AstroGypsophila
+ * Github  : https://github.com/AstroGypsophila
+ * Date   : 2016/8/28
+ */
+public interface OnLoadNewsListListener {
+
+    void onSuccess(List<NewsBean> list);
+
+    void onFailure(String msg, Exception e);
+}

--- a/app/src/main/java/com/lauren/simplenews/news/presenter/NewsDetailPresenterImpl.java
+++ b/app/src/main/java/com/lauren/simplenews/news/presenter/NewsDetailPresenterImpl.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import com.lauren.simplenews.beans.NewsDetailBean;
 import com.lauren.simplenews.news.model.NewsModel;
 import com.lauren.simplenews.news.model.NewsModelImpl;
+import com.lauren.simplenews.news.model.OnLoadNewsDetailListener;
 import com.lauren.simplenews.news.view.NewsDetailView;
 
 /**
@@ -14,7 +15,7 @@ import com.lauren.simplenews.news.view.NewsDetailView;
  * Blog   : http://www.liuling123.com
  * Date   : 2015/12/21
  */
-public class NewsDetailPresenterImpl implements NewsDetailPresenter, NewsModelImpl.OnLoadNewsDetailListener {
+public class NewsDetailPresenterImpl implements NewsDetailPresenter, OnLoadNewsDetailListener {
 
     private Context mContent;
     private NewsDetailView mNewsDetailView;
@@ -35,7 +36,7 @@ public class NewsDetailPresenterImpl implements NewsDetailPresenter, NewsModelIm
 
     @Override
     public void onSuccess(NewsDetailBean newsDetailBean) {
-        if(newsDetailBean != null) {
+        if (newsDetailBean != null) {
             mNewsDetailView.showNewsDetialContent(newsDetailBean.getBody());
         }
         mNewsDetailView.hideProgress();

--- a/app/src/main/java/com/lauren/simplenews/news/presenter/NewsPresenterImpl.java
+++ b/app/src/main/java/com/lauren/simplenews/news/presenter/NewsPresenterImpl.java
@@ -4,6 +4,7 @@ import com.lauren.simplenews.beans.NewsBean;
 import com.lauren.simplenews.commons.Urls;
 import com.lauren.simplenews.news.model.NewsModel;
 import com.lauren.simplenews.news.model.NewsModelImpl;
+import com.lauren.simplenews.news.model.OnLoadNewsListListener;
 import com.lauren.simplenews.news.view.NewsView;
 import com.lauren.simplenews.news.widget.NewsFragment;
 import com.lauren.simplenews.utils.LogUtils;
@@ -17,7 +18,7 @@ import java.util.List;
  * Blog   : http://www.liuling123.com
  * Date   : 15/12/18
  */
-public class NewsPresenterImpl implements NewsPresenter, NewsModelImpl.OnLoadNewsListListener {
+public class NewsPresenterImpl implements NewsPresenter, OnLoadNewsListListener {
 
     private static final String TAG = "NewsPresenterImpl";
 

--- a/app/src/main/java/com/lauren/simplenews/news/widget/NewsListFragment.java
+++ b/app/src/main/java/com/lauren/simplenews/news/widget/NewsListFragment.java
@@ -115,6 +115,9 @@ public class NewsListFragment extends Fragment implements NewsView, SwipeRefresh
     private NewsAdapter.OnItemClickListener mOnItemClickListener = new NewsAdapter.OnItemClickListener() {
         @Override
         public void onItemClick(View view, int position) {
+            if (mData.size() <= 0) {
+                return;
+            }
             NewsBean news = mAdapter.getItem(position);
             Intent intent = new Intent(getActivity(), NewsDetailActivity.class);
             intent.putExtra("news", news);


### PR DESCRIPTION
Interface is used to develop specifications and don't need care for the
specific content of its implementations class because of its
reusability.Therefore,we should move the inner interface of
NewsModelImpl.